### PR TITLE
Use method routeMultipleLong instead of routeMultiple in order to avoid conflict with HibernationFixup

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,5 +1,8 @@
 DebugEnhancer Changelog
 ============================
+#### v1.0.4
+- Use method routeMultipleLong instead of routeMultiple in order to avoid conflict with HibernationFixup
+
 #### v1.0.3
 - Added constants for macOS 12 support
 

--- a/DebugEnhancer/kern_dbgenhancer.cpp
+++ b/DebugEnhancer/kern_dbgenhancer.cpp
@@ -113,7 +113,7 @@ void DBGENH::processKernel(KernelPatcher &patcher)
 				{"_hibernate_write_image", hibernate_write_image, org_hibernate_write_image},
 				{"_IOHibernateSystemSleep", IOHibernateSystemSleep, orgIOHibernateSystemSleep}
 			};
-			if (!patcher.routeMultiple(KernelPatcher::KernelID, requests, arrsize(requests)))
+			if (!patcher.routeMultipleLong(KernelPatcher::KernelID, requests, arrsize(requests)))
 				SYSLOG("DBGENH", "patcher.routeMultiple for %s is failed with error %d", requests[0].symbol, patcher.getError());
 		} else
 			SYSLOG("DBGENH", "Symbol _vprintf cannot be resolved with error %d", patcher.getError());


### PR DESCRIPTION
`_IOHibernateSystemSleep` is routed in both plugins thus cause kp with "previous plugin had short jump type on a multiroute function, this is not allowed".

See also https://github.com/acidanthera/HibernationFixup/pull/1